### PR TITLE
Initialize Vercel-ready Next.js starter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "react/jsx-sort-props": [
+      "error",
+      {
+        "callbacksLast": true,
+        "shorthandFirst": true,
+        "ignoreCase": true,
+        "noSortAlphabetically": false
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules
+.next
+out
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+dist
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.DS_Store
+*.log
+.vercel

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# repoops-v4-vercel
+# RepoOps V4 – Vercel Ready Starter
+
+A minimal-yet-opinionated Next.js 14 starter wired for Vercel deployments. It ships with the App Router, TypeScript, Tailwind CSS, and linting defaults so you can bootstrap new projects quickly.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+Visit http://localhost:3000 to confirm the landing page renders.
+
+## Available scripts
+
+- `npm run dev` – start the local development server.
+- `npm run build` – create an optimized production build.
+- `npm run start` – serve the production build locally.
+- `npm run lint` – run ESLint using the Next.js config.
+
+## Deployment
+
+The configuration is tuned for Vercel. Push the repository to GitHub and import it into Vercel to provision preview deployments automatically. When you are ready, promote a preview to production or trigger a `vercel --prod` deployment.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,13 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  eslint: {
+    dirs: ["src"],
+  },
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "repoops-v4-vercel",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.79",
+    "autoprefixer": "10.4.17",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#22d3ee" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0f172a" />
+  <path
+    fill="url(#g)"
+    d="M18 20h10l4 8 4-8h10l-14 24z"
+  />
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,24 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: rgb(9 9 11);
+  color: rgb(244 244 245);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,14 @@
+export default function Icon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <defs>
+        <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#6366f1" />
+          <stop offset="100%" stopColor="#22d3ee" />
+        </linearGradient>
+      </defs>
+      <rect width="64" height="64" rx="14" fill="#0f172a" />
+      <path fill="url(#gradient)" d="M18 20h10l4 8 4-8h10l-14 24z" />
+    </svg>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "RepoOps V4",
+  description:
+    "Operational Next.js starter tailored for Vercel deployments with sensible defaults.",
+};
+
+type RootLayoutProps = Readonly<{
+  children: React.ReactNode;
+}>;
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en" className="bg-zinc-950 text-zinc-100">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+
+const resources = [
+  {
+    href: "https://nextjs.org/docs",
+    title: "Next.js Docs",
+    description: "Learn about features like the App Router, Server Actions, and more.",
+  },
+  {
+    href: "https://vercel.com/docs",
+    title: "Vercel Guides",
+    description: "Ship confidently with deployment, monitoring, and storage playbooks.",
+  },
+  {
+    href: "https://tailwindcss.com/docs",
+    title: "Tailwind CSS",
+    description: "Compose beautiful interfaces with utility-first design primitives.",
+  },
+];
+
+export default function HomePage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-16 px-6 py-24">
+      <header className="flex flex-col gap-4 text-balance">
+        <p className="text-sm uppercase tracking-[0.4em] text-zinc-400">RepoOps</p>
+        <h1 className="text-4xl font-semibold sm:text-5xl">
+          Spin up a production-ready Next.js workspace in minutes.
+        </h1>
+        <p className="max-w-2xl text-lg text-zinc-400">
+          This template pairs the Next.js App Router, Tailwind CSS styling, and curated linting
+          defaults so you can focus on building features instead of configuration chores.
+        </p>
+      </header>
+
+      <section className="grid gap-6 sm:grid-cols-2">
+        {resources.map((resource) => (
+          <Link
+            key={resource.href}
+            href={resource.href}
+            className="group rounded-2xl border border-zinc-800 bg-zinc-900/40 p-6 transition hover:border-zinc-500 hover:bg-zinc-900/80"
+          >
+            <h2 className="text-xl font-semibold text-zinc-100 group-hover:text-white">
+              {resource.title}
+            </h2>
+            <p className="mt-2 text-sm text-zinc-400 group-hover:text-zinc-300">
+              {resource.description}
+            </p>
+          </Link>
+        ))}
+      </section>
+
+      <footer className="text-sm text-zinc-500">
+        Ready to deploy? Run <code className="rounded bg-zinc-800 px-2 py-1">npm run build</code> and
+        ship to Vercel.
+      </footer>
+    </main>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es5"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 project with TypeScript, Tailwind CSS, and opinionated linting defaults
- add an introductory landing page highlighting RepoOps resources and deployment guidance
- document usage and deployment steps for the Vercel-focused starter in the README

## Testing
- npm run lint *(fails: Next.js not installed because npm registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ff469c60832c964431923d28689f