### PR TITLE
test(ci): trigger Vercel preview deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,26 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run build
+  vercel_preview:
+    if: ${{ github.event_name == 'pull_request' && secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
+    needs: node_ci
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci --no-audit --no-fund
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel environment information
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+      - name: Build project with Vercel
+        run: vercel build --token="$VERCEL_TOKEN"
+      - name: Deploy preview to Vercel
+        run: vercel deploy --prebuilt --token="$VERCEL_TOKEN"


### PR DESCRIPTION
## Summary
- add a conditional Vercel preview deployment job to the CI workflow
- install the Vercel CLI and run pull/build/deploy steps when secrets are available

## Testing
- npm ci *(fails: 403 Forbidden from registry.npmjs.org while downloading @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68e445719bb8832c90f7c83ad9a7c36f