### PR TITLE
Document deployment blockers due to npm proxy issues

### DIFF
--- a/DEPLOYMENT_LOG.md
+++ b/DEPLOYMENT_LOG.md
@@ -1,0 +1,12 @@
+# Deployment Attempt Log
+
+- `npm install` fails because the environment's proxy at `http://proxy:8080` returns HTTP 403 for npm registry requests, while disabling the proxy produces `ENETUNREACH` errors preventing any downloads.
+- Without installed dependencies, `npm run build` fails (`next: not found`).
+- Installing the Vercel CLI via `npm install -g vercel` also cannot proceed because it cannot reach the registry.
+- Consequently, `vercel --prod` is unavailable for deployment.
+- Commands attempted:
+  - `npm install`
+  - `npm_config_progress=false npm install --loglevel=info`
+  - `npm run build`
+  - `npm_config_progress=false npm install -g vercel`
+  - `vercel --prod`


### PR DESCRIPTION
## Summary
- add a deployment log that records failed attempts to install dependencies, build, and deploy due to proxy/network restrictions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e498cd3c10832cb6bfaa1910300295